### PR TITLE
fix(typo): README.md instructions to install with Packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 Using packer
 
 ```lua
-use 'yavko/minimap.lua'
+use 'yavko/minimap.nvim'
 ```
 
 


### PR DESCRIPTION
Mismatch between the name of the repo and the `use` statement prevented PackerSync to work properly.

With this version it works, at least with my setup

Related to this closed PR : https://github.com/yavko/minimap.nvim/pull/1 that was autoclosed by a bot.

Let me know if you require additional information.

Thanks for the work :pray: 

<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

Mismatch between the name of the repo and the `use` statement prevented PackerSync to work properly.

With this version it works, at least with my setup

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: v.0.9.4
    - [ ] Vim: <Version>
